### PR TITLE
add motion detection

### DIFF
--- a/MMM-Ring.js
+++ b/MMM-Ring.js
@@ -20,6 +20,7 @@ Module.register("MMM-Ring", {
   defaults: {
     ringEmail: undefined,
     ringPwd: undefined,
+    ringStreamMotion: false,
     ring2faRefreshToken: undefined,
     ringMinutesToStreamVideo: 1.5,
     ringVideoWidth: "600"

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ To use this module, add the following configuration block to the modules array i
 | `ring2faRefreshToken`      | (_Required_) Look at the [Refresh Tokens](https://github.com/DustinBryant/MMM-Ring/wiki/Refresh-Tokens)) wiki entry for how to set this up. |
 | `ringMinutesToStreamVideo` | (_Optional_) How long a ding event video stream should last before ending. MAX 5 minutes! <br><br>**Type:** `int`(minutes) <br>Default: 1.5 |
 | `ringVideoWidth`           | (_Optional_) Width of the video display. <br><br>**Type:** `string`(px) <br>Default: "600"                                                  |
+| `ringStreamMotion`           | (_Optional_) Displays stream if there is motion, not just a ring. <br><br>**Type:** `boolean`(true/false) <br>Default: false                                                  |
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ The original developer of this module no longer has a Ring device and has since 
 
 This is a module for the [MagicMirror²](https://github.com/MichMich/MagicMirror/).
 
-Whenever someone rings your doorbell by pressing the button on your ring device, a video will appear wherever the module is placed within MM. This module will only work for ding events and will not do anything for motion events. Whenever there is no video being displayed nothing else is shown in its place.
+Whenever someone rings your doorbell by pressing the button on your ring device, or when motion is detected a video will appear wherever the module is placed within MM. Whenever there is no video being displayed nothing else is shown in its place.
 
 **Caveats:**
 
 - Must have an active Ring subscription
-- Only works with someone ringing your doorbell (no motion events).
+- Works with someone ringing your doorbell or motion at cameras.
 - There is a slight unavoidable delay (couple seconds) with the videos.
-- In your ring app, all of these events will show as answered rings. This may get fixed in the future.
+- In your ring app, all of these events will show as answered rings or answered motion. This may get fixed in the future.
 - You will not be able to interact, talk with, or hear the person on the other end through MM.
 - The RingAPI being used is unofficial which means there could be potential issues if Ring ever decides to make changes.
 - Though it will work most of the time, there are slight chances a video may not get picked up/streamed properly. This is due partly because of using an unoffical API and sometimes hls (video component used for streaming) picks up the stream too early or faults for other reasons.
@@ -52,7 +52,7 @@ To use this module, add the following configuration block to the modules array i
 | `ring2faRefreshToken`      | (_Required_) Look at the [Refresh Tokens](https://github.com/DustinBryant/MMM-Ring/wiki/Refresh-Tokens)) wiki entry for how to set this up. |
 | `ringMinutesToStreamVideo` | (_Optional_) How long a ding event video stream should last before ending. MAX 5 minutes! <br><br>**Type:** `int`(minutes) <br>Default: 1.5 |
 | `ringVideoWidth`           | (_Optional_) Width of the video display. <br><br>**Type:** `string`(px) <br>Default: "600"                                                  |
-| `ringStreamMotion`           | (_Optional_) Displays stream if there is motion, not just a ring. <br><br>**Type:** `boolean`(true/false) <br>Default: false                                                  |
+| `ringStreamMotion`           | (_Optional_) Displays stream if there is motion, not just a ring. If more than one motion event or doorbell press happens within the "ringMinutesToStreamVideo" length of time it will prioitize the first even that was triggered. Motion can also not be triggered more than once within 65 seconds.  <br><br>**Type:** `boolean`(true/false) <br>Default: false                                                  |
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Whenever someone rings your doorbell by pressing the button on your ring device,
 **Caveats:**
 
 - Must have an active Ring subscription
-- Works with someone ringing your doorbell or motion at cameras.
+- Only displays the earliest stream sent to it with no way to view multiple streams.
 - There is a slight unavoidable delay (couple seconds) with the videos.
 - In your ring app, all of these events will show as answered rings or answered motion. This may get fixed in the future.
 - You will not be able to interact, talk with, or hear the person on the other end through MM.
@@ -52,7 +52,7 @@ To use this module, add the following configuration block to the modules array i
 | `ring2faRefreshToken`      | (_Required_) Look at the [Refresh Tokens](https://github.com/DustinBryant/MMM-Ring/wiki/Refresh-Tokens)) wiki entry for how to set this up. |
 | `ringMinutesToStreamVideo` | (_Optional_) How long a ding event video stream should last before ending. MAX 5 minutes! <br><br>**Type:** `int`(minutes) <br>Default: 1.5 |
 | `ringVideoWidth`           | (_Optional_) Width of the video display. <br><br>**Type:** `string`(px) <br>Default: "600"                                                  |
-| `ringStreamMotion`           | (_Optional_) Displays stream if there is motion, not just a ring. If more than one motion event or doorbell press happens within the "ringMinutesToStreamVideo" length of time it will prioitize the first even that was triggered. Motion can also not be triggered more than once within 65 seconds.  <br><br>**Type:** `boolean`(true/false) <br>Default: false                                                  |
+| `ringStreamMotion`           | (_Optional_) Displays stream if there is motion, not just a ring. If more than one motion event or doorbell press happens within the "ringMinutesToStreamVideo" length of time it will prioitize the first event that was triggered. Motion can also not be triggered more than once within 65 seconds.  <br><br>**Type:** `boolean`(true/false) <br>Default: false                                                  |
 
 ## Dependencies
 

--- a/node_helper.js
+++ b/node_helper.js
@@ -149,33 +149,41 @@ module.exports = NodeHelper.create({
     allCameras.forEach((camera) => {
       camera.onDoorbellPressed.subscribe(async () => {
         if (!this.sipSession) {
-          await this.startSession(camera);
+          await this.startSession(camera, "ring");
         }
       });
+      this.toLog(`Actively listening for doorbell presses`);
       //Check config value if node app should stream motion
       if(this.config.ringStreamMotion){
         camera.onMotionDetected.subscribe(async (newMotion) => {
           //NewMotion is a true false value indicating whether the motion is new based on the dings made in the last 65 seconds
-          // This in theory isn't needed because other logic handles calling duplicate streams but this is best practice.
+          // This prevents the stream from being triggered on startup because it would not be an active motion event.
           if (!this.sipSession && newMotion) {
-            this.toLog("Found Motion");
-            await this.startSession(camera);
+            await this.startSession(camera, "motion");
           }
         });
+        this.toLog(`Actively listening for Motion events`);
       }
       
     });
 
-    this.toLog(`Actively listening for doorbell presses`);
+    
   },
 
-  startSession: async function (camera) {
+  startSession: async function (camera, type) {
     if (this.sipSession || this.sessionRunning === true) {
       return;
     }
 
     this.sessionRunning = true;
-    this.toLog(`${camera.name} had its doorbell rung! Preparing video stream.`);
+    if(type === "ring"){
+      this.toLog(`${camera.name} had its doorbell rung! Preparing video stream.`);
+    }else if(type === "motion"){
+      this.toLog(`${camera.name} has sensed motion Preparing video stream.`);
+    }else{
+      this.toLog(`${camera.name} been summoned by something other than a ring or motion. (spooky) Preparing video stream.`); 
+    }
+    
 
     await this.cleanUpVideoStreamDirectory();
     this.watchForStreamStarted();

--- a/node_helper.js
+++ b/node_helper.js
@@ -152,6 +152,18 @@ module.exports = NodeHelper.create({
           await this.startSession(camera);
         }
       });
+      //Check config value if node app should stream motion
+      if(this.config.ringStreamMotion){
+        camera.onMotionDetected.subscribe(async (newMotion) => {
+          //NewMotion is a true false value indicating whether the motion is new based on the dings made in the last 65 seconds
+          // This in theory isn't needed because other logic handles calling duplicate streams but this is best practice.
+          if (!this.sipSession && newMotion) {
+            this.toLog("Found Motion");
+            await this.startSession(camera);
+          }
+        });
+      }
+      
     });
 
     this.toLog(`Actively listening for doorbell presses`);


### PR DESCRIPTION
This adds a simple config and some logic to start the stream with motion aswell and door dings. This was tested on a ring video doorbell (pro i think) no testing has been done for the standalone cameras or multiple cameras however it's a simple api call so it should in theory work. there was no testing branch so this is going to master.

This doesn't prioritize which stream pops up as mentioned in the enhancement because I would have no way of testing it. Meaning in theory if more than one event happened it would just stream the first one that occurred until the stream stops and another motion event can be triggered.